### PR TITLE
Fix date validation when fields missing

### DIFF
--- a/validate_date.js
+++ b/validate_date.js
@@ -5,8 +5,15 @@
 
   kintone.events.on(submitEvents, function (event) {
     const r = event.record;
-    const start = r.開始日.value;
-    const end   = r.終了日.value;
+    const startField = r.開始日;
+    const endField   = r.終了日;
+
+    if (!startField || !endField) {
+      return event; // Avoid runtime errors if field codes are wrong
+    }
+
+    const start = startField.value;
+    const end   = endField.value;
 
     if (start && end && new Date(start) > new Date(end)) {
  //     r.終了日.error = "終了日は開始日以降の日付を指定してください"; // 問題箇所にエラー表示(フィールド幅で改行される)


### PR DESCRIPTION
## Summary
- prevent runtime errors if start/end fields are missing in `validate_date.js`

## Testing
- `node -c validate_date.js`